### PR TITLE
feat: redirect to new domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flad-mentorship",
+  "name": "letstalkaboutbusiness",
   "version": "1.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,11 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
+    <script>
+      if (location.host === "flad-mentorship.firebaseapp.com") {
+        location.href = "https://letstalkaboutbusiness.org/";
+      }
+    </script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -22,7 +27,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>FLAD Mentorship</title>
+
+    <title>Let's Talk About Business</title>
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>


### PR DESCRIPTION
The setup of our new custom domain: https://letstalkaboutbusiness.org/ is ready but now we need to redirect users that are still using https://flad-mentorship.firebaseapp.com to the new domain. 

Firebase does not allow to delete default domains and the app will be always serve there. However, we are performing a client side redirect with JavaScript to avoid users navigate the app under the old domain.

Related to #58